### PR TITLE
[fix/map] 맵 초기 렌더링 시 zoom이 제대로 먹지 않는 부분 수정

### DIFF
--- a/src/app/(post)/posts/[id]/page.tsx
+++ b/src/app/(post)/posts/[id]/page.tsx
@@ -35,7 +35,7 @@ const PostDetailPage = async ({ params }: { params: { id: string } }) => {
   const data = await getData(params.id);
 
   if (!data) {
-    return <Empty className="border-none text-[20px]" />;
+    return <Empty className="border-none text-[16px] font-semibold" />;
   }
 
   return (

--- a/src/components/home/contents/map/canvas.tsx
+++ b/src/components/home/contents/map/canvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC, useCallback, useState } from "react";
+import { FC, useLayoutEffect, useState } from "react";
 import { Countries } from "../types";
 
 import { GoogleMap, Marker, useJsApiLoader } from "@react-google-maps/api";
@@ -16,45 +16,32 @@ const MapCanvas: FC<MapCanvasProps> = ({ selectedCountry }) => {
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "",
   });
 
-  const [map, setMap] = useState(null);
+  const [zoom, setZoom] = useState(1);
 
-  const onLoad = useCallback(function callback(map: any) {
-    // This is just an example of getting and using the map instance!!! don't just blindly copy!
-    const bounds = new window.google.maps.LatLngBounds(
-      location.Australia,
-      location.France
-    );
-    map.fitBounds(bounds);
-
-    setMap(map);
-  }, []);
-
-  const onUnmount = useCallback(function callback(map: any) {
-    setMap(null);
+  useLayoutEffect(() => {
+    setZoom(6);
   }, []);
 
   return isLoaded ? (
-    <div className="w-full bg-transparent h-[500px] px-[16px] sm:h-[680px]">
+    <div className="w-full h-[280px] px-[16px] sm:h-[380px] md:h-[680px]">
       <GoogleMap
+        zoom={zoom}
         mapContainerStyle={{ height: "100%", width: "100%" }}
         mapContainerClassName="h-full"
         center={
           selectedCountry ? location[selectedCountry] : location.Australia
         }
-        zoom={2}
-        onLoad={onLoad}
-        onUnmount={onUnmount}
       >
         {selectedCountry && (
           <Marker
             position={location[selectedCountry]}
             title={locationTitle[selectedCountry]}
-          ></Marker>
+          />
         )}
       </GoogleMap>
     </div>
   ) : (
-    <div>loading...</div>
+    <div className="my-[8px] flex justify-center">loading...</div>
   );
 };
 


### PR DESCRIPTION
구글 맵 컴포넌트를 초기 렌더링 시에 zoom 값을 주었는데도 불구하고 제대로 원하는 level의 zoom이 설정되지 않는 문제가 있었음.

맵이 렌더링 된 이후에 hmr로 리로드 시에는 이미 맵이 화면에 그려져 있었기 때문에 zoom이 제대로 동작.

useEffect에서 zoom 값을 업데이트 해서 props로 넘겨주어도 zoom의 상태 변경에 대해서 GoogleMap 컴포넌트에서 동작하지 않는 것 같았음(맵이 그려지는 순간의 zoom 값을 보는 것 같음 아마도 페인트 단계에서?)


이를 해결하기 위해 zoom 값을 useState로 상태 관리 후 useLayoutEffect 훅 안에서 상태를 업데이트 시켜서 페인트 직전에
zoom 값이 설정되도록 수정. (이미 맵이 flow 단계는 거쳤기 때문에 layout은 있고 paint만 새로 하면 되기 때문에)