### PR TITLE
[feature/post] 포스팅 페이지 header 스크롤 시 타이틀 노출

### DIFF
--- a/src/app/(post)/layout.tsx
+++ b/src/app/(post)/layout.tsx
@@ -7,7 +7,7 @@ const PostsLayout = ({
   children: React.ReactNode;
 }>) => {
   return (
-    <div className="w-full">
+    <div className="w-full h-full">
       {/* <div>포스팅 목록입니다.</div> */}
       <Navigator />
       <Toaster />

--- a/src/app/(post)/posts/[id]/page.tsx
+++ b/src/app/(post)/posts/[id]/page.tsx
@@ -5,6 +5,7 @@
 
 import Empty from "@/components/common/empty";
 import { Countries } from "@/components/home/contents/types";
+import PostTitle from "@/components/posts/post-title";
 import { client } from "@/contant/mongo";
 
 interface Contents {
@@ -39,8 +40,8 @@ const PostDetailPage = async ({ params }: { params: { id: string } }) => {
   }
 
   return (
-    <div className="w-full flex justify-center p-[24px] gap-[8px] flex-col items-center">
-      <h1 className="text-[28px] font-semibold">{data.title}</h1>
+    <div className="w-full h-full flex justify-center p-[24px] gap-[8px] flex-col items-center">
+      <PostTitle title={data.title} />
       <div className="text-[14px] content max-w-[800px] mt-[32px] grid grid-cols-1 gap-[12px] justify-center p-[24px] bg-gray-50 rounded-[8px]">
         <div dangerouslySetInnerHTML={{ __html: data.contents }} />
       </div>

--- a/src/components/common/navigator.tsx
+++ b/src/components/common/navigator.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 const Navigator = () => {
   return (
-    <div className="w-full flex items-center justify-between bg-white p-[16px] sticky">
+    <div className="w-full sticky top-0 flex items-center justify-between bg-white p-[16px]">
       <Link href="/" className="flex items-center gap-x-[6px]">
         <div className="border border-gray-200 shadow-md rounded-full size-fit cursor-pointer">
           <Image src="/profile.png" alt="thumbnail" width={50} height={50} />

--- a/src/components/posts/post-title.tsx
+++ b/src/components/posts/post-title.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { FC, useEffect, useRef, useState } from "react";
+
+interface PostTitleProps {
+  title: string;
+}
+
+const PostTitle: FC<PostTitleProps> = ({ title }) => {
+  const titleRef = useRef<HTMLDivElement | null>(null);
+
+  const [isVisible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((args) => {
+      const [target] = args;
+
+      setVisible(target.isIntersecting);
+    });
+
+    if (titleRef.current) {
+      observer.observe(titleRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <div>
+      <div ref={titleRef} className={"text-[24px] font-semibold"}>
+        {title}
+      </div>
+      {!isVisible && (
+        <div className="fixed font-medium text-[14px] right-6 top-[33px] sm:left-[160px]">
+          {title}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PostTitle;


### PR DESCRIPTION
- 포스팅 페이지에서 스크롤 시 헤더가 고정되지 않는 부분 수정하면서 포스팅 타이틀도 보일 수 있도록 수정했습니다.