### PR TITLE
feat: modal(dialog) 생성

### DIFF
--- a/src/app/videos/page.tsx
+++ b/src/app/videos/page.tsx
@@ -1,11 +1,12 @@
 import Video from "@/components/videos";
 
-const Photograph = () => {
+const Videos = () => {
   return (
     <div className="bg-gray-950 h-[calc(100vh-84px)]">
       <Video />
+      <div className="w-full h-px bg-white" />
     </div>
   );
 };
 
-export default Photograph;
+export default Videos;

--- a/src/components/home/contents/image-carousel/image-carousel-item.tsx
+++ b/src/components/home/contents/image-carousel/image-carousel-item.tsx
@@ -15,7 +15,7 @@ const ImageCarouselItem: FC<ImageCarouselItemProps> = ({
   alt = imageUrl,
 }) => {
   return (
-    <div className="border h-[380px] w-[340px] border-gray-100 relative rounded-[8px]">
+    <div className="border h-[380px] w-[352px] border-gray-100 relative rounded-[8px]">
       <Image
         className="rounded-[8px]"
         src={imageUrl}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -40,7 +40,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,24 +1,49 @@
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { FC, ReactNode } from "react";
 
-import { Dialog, DialogContent,DialogTitle, DialogTrigger } from "./dialog";
+import { useModalActionsContext, useModalStateContext } from "@/hooks/modal";
+
+import { Button } from "./button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+  DialogTrigger,
+} from "./dialog";
 
 interface ModalProps {
-  trigger: ReactNode;
+  trigger?: ReactNode;
   content: ReactNode;
   title?: ReactNode;
   showCloseButton?: boolean;
+  isOpen?: boolean;
+  onOpenChange?: (next: boolean) => void;
+  onConfirm?: () => void;
+  onCancel?: () => void;
 }
 
 const Modal: FC<ModalProps> = ({
   trigger,
   title,
   content,
+  onCancel,
+  onConfirm,
   showCloseButton = false,
 }) => {
+  const { isOpen } = useModalStateContext();
+  const { onChangeOpen } = useModalActionsContext();
+
   return (
-    <Dialog>
-      <DialogTrigger className="w-fit">{trigger}</DialogTrigger>
+    <Dialog open={isOpen} onOpenChange={onChangeOpen}>
+      {trigger ? (
+        <DialogTrigger>{trigger}</DialogTrigger>
+      ) : (
+        <VisuallyHidden.Root>
+          <DialogTrigger />
+        </VisuallyHidden.Root>
+      )}
       {title ? (
         <DialogTitle>{title}</DialogTitle>
       ) : (
@@ -26,7 +51,31 @@ const Modal: FC<ModalProps> = ({
           <DialogTitle />
         </VisuallyHidden.Root>
       )}
-      <DialogContent showCloseButton={showCloseButton}>{content}</DialogContent>
+      <DialogContent showCloseButton={showCloseButton}>
+        {content}
+        <DialogFooter>
+          <div className="w-full grid grid-cols-2 gap-x-[8px]">
+            <Button
+              tabIndex={-1}
+              onClick={onCancel}
+              variant="outline"
+              className="h-[46px] border-red-500"
+            >
+              취소
+            </Button>
+            <Button
+              onClick={onConfirm}
+              variant="default"
+              className="border-red-500 bg-red-500 text-white h-[46px] hover:bg-red-600"
+            >
+              확인
+            </Button>
+          </div>
+        </DialogFooter>
+        <VisuallyHidden.Root>
+          <DialogDescription />
+        </VisuallyHidden.Root>
+      </DialogContent>
     </Dialog>
   );
 };

--- a/src/context/modal/index.tsx
+++ b/src/context/modal/index.tsx
@@ -1,0 +1,37 @@
+import { createContext, FC, ReactNode, useRef, useState } from "react";
+
+import {
+  ModalActionsContext,
+  ModalProviderProps,
+  ModalStateContext,
+} from "./types";
+
+export const StateContext = createContext<ModalStateContext>({
+  isOpen: false,
+  modalRef: { current: null },
+});
+
+export const ActionsContext = createContext<ModalActionsContext>({
+  onChangeOpen: (_: boolean) => {},
+});
+
+const ModalProvider: FC<ModalProviderProps> = ({ children }) => {
+  const [isOpen, toggleOpen] = useState(false);
+
+  const modalRef = useRef<ReactNode | null>(null);
+
+  return (
+    <StateContext.Provider value={{ isOpen, modalRef }}>
+      <ActionsContext.Provider
+        value={{
+          onChangeOpen: toggleOpen,
+        }}
+      >
+        {children}
+        {modalRef.current}
+      </ActionsContext.Provider>
+    </StateContext.Provider>
+  );
+};
+
+export default ModalProvider;

--- a/src/context/modal/types.ts
+++ b/src/context/modal/types.ts
@@ -1,0 +1,14 @@
+import { MutableRefObject, ReactNode } from "react";
+
+export interface ModalStateContext {
+  isOpen: boolean;
+  modalRef: MutableRefObject<ReactNode>;
+}
+
+export interface ModalActionsContext {
+  onChangeOpen: (next: boolean) => void;
+}
+
+export interface ModalProviderProps {
+  children: ReactNode;
+}

--- a/src/hooks/modal/index.tsx
+++ b/src/hooks/modal/index.tsx
@@ -1,0 +1,69 @@
+import { ReactNode, useContext } from "react";
+
+import Modal from "@/components/ui/modal";
+import { ActionsContext, StateContext } from "@/context/modal";
+
+interface OpenModalParams {
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  children: ReactNode;
+}
+
+export const useModalStateContext = () => {
+  const context = useContext(StateContext);
+
+  if (!context) {
+    throw new Error("useModalStateContext must be used within a ModalProvider");
+  }
+
+  return context;
+};
+
+export const useModalActionsContext = () => {
+  const context = useContext(ActionsContext);
+
+  if (!context) {
+    throw new Error(
+      "useModalActionsContext must be used within a ModalProvider"
+    );
+  }
+
+  return context;
+};
+
+export const useModal = () => {
+  const { modalRef } = useModalStateContext();
+  const { onChangeOpen } = useModalActionsContext();
+
+  const open = ({ onConfirm, onCancel, children }: OpenModalParams) => {
+    onChangeOpen(true);
+
+    const promise = new Promise<boolean>((resolve) => {
+      modalRef.current = (
+        <Modal
+          onConfirm={() => {
+            onConfirm?.();
+            resolve(true);
+          }}
+          onCancel={() => {
+            onCancel?.();
+            resolve(false);
+          }}
+          content={children}
+        />
+      );
+    });
+
+    return promise;
+  };
+
+  const close = () => {
+    onChangeOpen(false);
+    modalRef.current = null;
+  };
+
+  return {
+    open,
+    close,
+  };
+};


### PR DESCRIPTION
매번 다이얼로그(modal)을 사용할 때마다 trigger 컴포넌트와 content 컴포넌트로 감싸기 보다는
modal hook을 만들어 click event 때 모달을 띄울 수 있도록 context provider 생성 및 open/close 함수 생성

promise와 함께 사용하여 취소/확인 시 해당 값에 따라서 다음 액션을 취할 수 있도록 구현