### PR TITLE
feat: 통합 디자인 시스템 리디자인 - 다크 테마 기반 전 페이지 일관된 UI/UX 통일

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-error-boundary": "^4.1.1",
-        "react-quill": "^2.0.0",
+        "react-quill-new": "^3.8.3",
         "sharp": "^0.33.5",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7"
@@ -2580,14 +2580,6 @@
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
       "devOptional": true
     },
-    "node_modules/@types/quill": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
-      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
-      "dependencies": {
-        "parchment": "^1.1.2"
-      }
-    },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
@@ -3211,6 +3203,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3335,14 +3328,6 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -3508,25 +3493,6 @@
         }
       }
     },
-    "node_modules/deep-equal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-      "dependencies": {
-        "is-arguments": "^1.1.1",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.5.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3537,6 +3503,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3553,6 +3520,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -3744,6 +3712,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4"
       },
@@ -3755,6 +3724,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4438,14 +4408,10 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4453,9 +4419,10 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -4662,6 +4629,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4670,6 +4638,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -4831,6 +4800,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -4872,6 +4842,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -4883,6 +4854,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4894,6 +4866,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4905,6 +4878,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -4997,21 +4971,6 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dependencies": {
         "loose-envify": "^1.0.0"
-      }
-    },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5145,6 +5104,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -5269,6 +5229,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -5577,10 +5538,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6331,25 +6306,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6509,9 +6470,10 @@
       }
     },
     "node_modules/parchment": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -6812,29 +6774,33 @@
       ]
     },
     "node_modules/quill": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "clone": "^2.1.1",
-        "deep-equal": "^1.0.1",
-        "eventemitter3": "^2.0.3",
-        "extend": "^3.0.2",
-        "parchment": "^1.1.4",
-        "quill-delta": "^3.6.2"
+        "eventemitter3": "^5.0.1",
+        "lodash-es": "^4.17.21",
+        "parchment": "^3.0.0",
+        "quill-delta": "^5.1.0"
+      },
+      "engines": {
+        "npm": ">=8.2.3"
       }
     },
     "node_modules/quill-delta": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "deep-equal": "^1.0.1",
-        "extend": "^3.0.2",
-        "fast-diff": "1.1.2"
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
       },
       "engines": {
-        "node": ">=0.10"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/react": {
@@ -6883,18 +6849,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
-    "node_modules/react-quill": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
-      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+    "node_modules/react-quill-new": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/react-quill-new/-/react-quill-new-3.8.3.tgz",
+      "integrity": "sha512-c96PYqFTo0pI4R3e79B3rH9LUIce1kIQbmTBu/imJQZk8305ogyLyBqKKjG2UoInDlquXqePSzmBo2aVia3ttw==",
+      "license": "MIT",
       "dependencies": {
-        "@types/quill": "^1.3.10",
-        "lodash": "^4.17.4",
-        "quill": "^1.3.7"
+        "lodash-es": "^4.17.21",
+        "quill": "~2.0.3"
       },
       "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
+        "quill-delta": "^5.1.0",
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-remove-scroll": {
@@ -7015,6 +6982,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
@@ -7189,6 +7157,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -7205,6 +7174,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-error-boundary": "^4.1.1",
-    "react-quill": "^2.0.0",
+    "react-quill-new": "^3.8.3",
     "sharp": "^0.33.5",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7"

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://travle-blog.vercel.app/posts</loc><lastmod>2025-12-18T15:34:12.975Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
-<url><loc>https://travle-blog.vercel.app/climbing</loc><lastmod>2025-12-18T15:34:12.976Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
-<url><loc>https://travle-blog.vercel.app</loc><lastmod>2025-12-18T15:34:12.976Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
-<url><loc>https://travle-blog.vercel.app/travel</loc><lastmod>2025-12-18T15:34:12.976Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
-<url><loc>https://travle-blog.vercel.app/videos</loc><lastmod>2025-12-18T15:34:12.976Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
+<url><loc>https://travle-blog.vercel.app/posts</loc><lastmod>2026-02-14T05:22:38.217Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
+<url><loc>https://travle-blog.vercel.app/climbing</loc><lastmod>2026-02-14T05:22:38.218Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
+<url><loc>https://travle-blog.vercel.app</loc><lastmod>2026-02-14T05:22:38.218Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
+<url><loc>https://travle-blog.vercel.app/travel</loc><lastmod>2026-02-14T05:22:38.218Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
+<url><loc>https://travle-blog.vercel.app/videos</loc><lastmod>2026-02-14T05:22:38.218Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
 </urlset>

--- a/src/app/(post)/layout.tsx
+++ b/src/app/(post)/layout.tsx
@@ -7,8 +7,7 @@ const PostsLayout = ({
   children: React.ReactNode;
 }>) => {
   return (
-    <div className="w-full h-full bg-white">
-      {/* <div>포스팅 목록입니다.</div> */}
+    <div className="w-full min-h-screen">
       <Navigator />
       <Toaster />
       {children}

--- a/src/app/(post)/posts/[id]/page.tsx
+++ b/src/app/(post)/posts/[id]/page.tsx
@@ -17,14 +17,14 @@ const PostDetailPage = async ({
 
   if (!data) {
     return (
-      <Empty className="text-[16px] mt-[64px] font-semibold text-center" />
+      <Empty className="text-base mt-16 font-semibold text-center" />
     );
   }
 
   return (
-    <div className="w-full h-full flex justify-center p-[24px] gap-[8px] flex-col items-center">
+    <div className="w-full flex justify-center p-6 gap-2 flex-col items-center">
       <PostTitle title={data.title} thumbnail={data.thumbnail} />
-      <div className="text-[15px] content max-w-[800px] mt-[16px] grid grid-cols-1 gap-[12px] justify-center p-[24px] bg-gray-50 rounded-[8px]">
+      <div className="text-sm content max-w-[800px] mt-4 grid grid-cols-1 gap-3 justify-center p-6 bg-surface-2 rounded-xl border border-border text-foreground">
         <div dangerouslySetInnerHTML={{ __html: data.contents }} />
       </div>
     </div>

--- a/src/app/(post)/write/page.tsx
+++ b/src/app/(post)/write/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import "react-quill/dist/quill.snow.css";
+import "react-quill-new/dist/quill.snow.css";
 
 import dynamic from "next/dynamic";
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import TripPostSelect from "@/components/travel/contents/trip-posts/trip-post-select";
 import { Button } from "@/components/ui/button";
@@ -11,7 +11,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { toolbarOptions } from "@/constant/editor";
 import { Countries } from "@/types";
 
-const ReactQuill = dynamic(() => import("react-quill"), { ssr: false });
+const ReactQuill = dynamic(() => import("react-quill-new"), { ssr: false });
 
 const WritePosts = () => {
   const [value, setValue] = useState("");
@@ -81,30 +81,33 @@ const WritePosts = () => {
   };
 
   return (
-    <div className="grid size-full grid-cols-1 px-[20px] gap-y-[20px]">
+    <div className="max-w-5xl mx-auto px-6 py-8 grid grid-cols-1 gap-y-6">
       <div>
         <input
           ref={title}
-          className="w-full h-[46px] outline-none text-[20px]"
+          className="w-full bg-transparent border-none outline-none text-2xl font-bold text-foreground placeholder:text-muted-foreground/40 pb-4"
           placeholder="제목을 입력하세요"
         />
-        <div className="h-px w-full bg-gray-100" />
+        <div className="h-px w-full bg-border" />
       </div>
-      <div className="flex items-center justify-between flex-wrap gap-y-[20px]">
+      <div className="flex items-center justify-between flex-wrap gap-4">
         <TripPostSelect
           setCountry={(value) => setCountry(value as Countries)}
         />
-        <div className="flex items-center gap-x-[8px] justify-end">
+        <div className="flex items-center gap-2 justify-end">
           <Button
             disabled
             onClick={handleTemporarySave}
-            variant="destructive"
-            className="w-[100px] h-[42px]"
+            variant="outline"
+            className="h-9 px-4 text-xs"
           >
-            임시저장 하기
+            임시저장
           </Button>
-          <Button className="w-[100px] h-[42px]" onClick={handleSavePost}>
-            업로드하기
+          <Button
+            className="h-9 px-4 text-xs bg-brand-cyan text-background hover:bg-brand-cyan/90"
+            onClick={handleSavePost}
+          >
+            업로드
           </Button>
         </div>
       </div>

--- a/src/app/climbing/layout.tsx
+++ b/src/app/climbing/layout.tsx
@@ -4,9 +4,9 @@ import Navigator from "@/components/common/navigator";
 
 const ClimbingLayout: FC<PropsWithChildren> = ({ children }) => {
   return (
-    <div className="w-full h-full">
+    <div className="w-full min-h-screen">
       <Navigator />
-      <div className="p-[16px]">{children}</div>
+      <div className="max-w-5xl mx-auto p-6">{children}</div>
     </div>
   );
 };

--- a/src/app/climbing/page.tsx
+++ b/src/app/climbing/page.tsx
@@ -1,50 +1,39 @@
 "use client";
 
+import { Mountain } from "lucide-react";
+
 import ClimbingCard from "@/components/climbing/card";
-import { Button } from "@/components/ui/button";
-
-// 킨디
-// 더클
-// 더클 성수, 사당, 일산, 강남
-
-// 클팍 성수
-// 왕십리 훅 클라이밍
-// 문정 닷 클라이밍
-// 역삼 볼더 하이웨이
 
 const ClimbingPage = () => {
   return (
     <div>
-      <header className="flex gap-x-[8px]">
-        <Button variant="outline" disabled>
-          암장 추가하기
-        </Button>
-      </header>
+      <div className="flex items-center gap-2 mb-6">
+        <Mountain size={20} className="text-brand-amber" />
+        <h1 className="text-2xl font-bold">Climbing</h1>
+      </div>
 
-      <div className="grid grid-cols-1 gap-[12px] mt-[16px]">
-        <p className="text-[18px] font-medium pl-[8px]">
-          내가 가봤던 암장들 😎 🧗
-        </p>
+      <p className="text-muted-foreground mb-6">
+        내가 가봤던 암장들
+      </p>
 
-        <div className="flex gap-[8px] flex-wrap sm:justify-normal justify-center">
-          <ClimbingCard
-            title="킨디 클라이밍"
-            imageUrl="/climbing/kin_d.png"
-            subTitle="주소 : 경기도 수원시 권선구 서둔동 388"
-          />
+      <div className="flex gap-4 flex-wrap sm:justify-normal justify-center">
+        <ClimbingCard
+          title="킨디 클라이밍"
+          imageUrl="/climbing/kin_d.png"
+          subTitle="경기도 수원시 권선구 서둔동 388"
+        />
 
-          <ClimbingCard
-            title="더클라임 강남점"
-            imageUrl="/climbing/theclimb_gangnam.png"
-            subTitle="주소: 서울특별시 강남구 테헤란로8길 21 지하 1층"
-          />
+        <ClimbingCard
+          title="더클라임 강남점"
+          imageUrl="/climbing/theclimb_gangnam.png"
+          subTitle="서울특별시 강남구 테헤란로8길 21 지하 1층"
+        />
 
-          <ClimbingCard
-            title="더클라임 성수점"
-            imageUrl="/climbing/theclimb_sungsu.jpg"
-            subTitle="주소 : 서울특별시 성동구 아차산로17길 49 지하 1층"
-          />
-        </div>
+        <ClimbingCard
+          title="더클라임 성수점"
+          imageUrl="/climbing/theclimb_sungsu.jpg"
+          subTitle="서울특별시 성동구 아차산로17길 49 지하 1층"
+        />
       </div>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,76 +1,114 @@
 @tailwind base;
-  @tailwind components;
-  @tailwind utilities;
+@tailwind components;
+@tailwind utilities;
 
-  @layer base {
-    :root {
-      --background: 0 0% 100%;
-      --foreground: 222.2 84% 4.9%;
+@layer base {
+  :root {
+    /* 다크 모드 기본 - 세련된 네이비 기반 */
+    --background: 220 20% 7%;
+    --foreground: 210 20% 92%;
 
-      --card: 0 0% 100%;
-      --card-foreground: 222.2 84% 4.9%;
+    --card: 220 18% 10%;
+    --card-foreground: 210 20% 92%;
 
-      --popover: 0 0% 100%;
-      --popover-foreground: 222.2 84% 4.9%;
+    --popover: 220 18% 10%;
+    --popover-foreground: 210 20% 92%;
 
-      --primary: 222.2 47.4% 11.2%;
-      --primary-foreground: 210 40% 98%;
+    --primary: 200 80% 60%;
+    --primary-foreground: 220 20% 7%;
 
-      --secondary: 210 40% 96.1%;
-      --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 220 16% 16%;
+    --secondary-foreground: 210 20% 85%;
 
-      --muted: 210 40% 96.1%;
-      --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 220 16% 14%;
+    --muted-foreground: 215 15% 55%;
 
-      --accent: 210 40% 96.1%;
-      --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 280 60% 65%;
+    --accent-foreground: 210 20% 95%;
 
-      --destructive: 0 84.2% 60.2%;
-      --destructive-foreground: 210 40% 98%;
+    --destructive: 0 72% 55%;
+    --destructive-foreground: 210 40% 98%;
 
-      --border: 214.3 31.8% 91.4%;
-      --input: 214.3 31.8% 91.4%;
-      --ring: 222.2 84% 4.9%;
+    --border: 220 16% 18%;
+    --input: 220 16% 18%;
+    --ring: 200 80% 60%;
 
-      --radius: 0.5rem;
-    }
+    --radius: 0.75rem;
 
-    .dark {
-      --background: 222.2 84% 4.9%;
-      --foreground: 210 40% 98%;
+    /* 커스텀 브랜드 컬러 */
+    --brand-cyan: 190 90% 55%;
+    --brand-violet: 280 60% 65%;
+    --brand-amber: 38 90% 60%;
+    --brand-rose: 350 70% 60%;
+    --brand-emerald: 160 60% 50%;
 
-      --card: 222.2 84% 4.9%;
-      --card-foreground: 210 40% 98%;
+    /* 서피스 (카드 내부 레이어링) */
+    --surface-1: 220 18% 10%;
+    --surface-2: 220 16% 13%;
+    --surface-3: 220 14% 16%;
+  }
+}
 
-      --popover: 222.2 84% 4.9%;
-      --popover-foreground: 210 40% 98%;
-
-      --primary: 210 40% 98%;
-      --primary-foreground: 222.2 47.4% 11.2%;
-
-      --secondary: 217.2 32.6% 17.5%;
-      --secondary-foreground: 210 40% 98%;
-
-      --muted: 217.2 32.6% 17.5%;
-      --muted-foreground: 215 20.2% 65.1%;
-
-      --accent: 217.2 32.6% 17.5%;
-      --accent-foreground: 210 40% 98%;
-
-      --destructive: 0 62.8% 30.6%;
-      --destructive-foreground: 210 40% 98%;
-
-      --border: 217.2 32.6% 17.5%;
-      --input: 217.2 32.6% 17.5%;
-      --ring: 212.7 26.8% 83.9%;
-    }
+@layer base {
+  * {
+    @apply border-border;
   }
 
-  @layer base {
-    * {
-      @apply border-border;
-    }
-    body {
-      @apply bg-background text-foreground;
-    }
+  body {
+    @apply bg-background text-foreground antialiased;
   }
+
+  /* 스크롤바 스타일 */
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: hsl(var(--background));
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: hsl(var(--muted-foreground) / 0.3);
+    border-radius: 3px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--muted-foreground) / 0.5);
+  }
+}
+
+/* 글로벌 유틸리티 */
+@layer utilities {
+  .text-gradient {
+    @apply bg-clip-text text-transparent;
+    background-image: linear-gradient(
+      135deg,
+      hsl(var(--brand-cyan)),
+      hsl(var(--brand-violet))
+    );
+  }
+
+  .border-gradient {
+    border-image: linear-gradient(
+        135deg,
+        hsl(var(--brand-cyan)),
+        hsl(var(--brand-violet))
+      )
+      1;
+  }
+
+  .glass {
+    backdrop-filter: blur(12px) saturate(180%);
+    background: hsl(var(--card) / 0.8);
+    border: 1px solid hsl(var(--border) / 0.5);
+  }
+
+  .glow-sm {
+    box-shadow: 0 0 15px -3px hsl(var(--brand-cyan) / 0.15);
+  }
+
+  .glow-md {
+    box-shadow: 0 0 30px -5px hsl(var(--brand-cyan) / 0.2);
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,8 +11,9 @@ import { VisitorProvider } from "@/hooks/visitor";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Supin's blog",
-  description: "나만의 블로그를 만들어보자",
+  title: "Supin's log",
+  description:
+    "Frontend Developer Supin Kim - Portfolio, Travel Blog & Life Log",
 };
 
 const pixelFont = Press_Start_2P({
@@ -27,11 +28,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={pixelFont.variable}>
-      <body className={inter.className}>
+    <html lang="ko" className={pixelFont.variable}>
+      <body className={`${inter.className} bg-background text-foreground`}>
         <Error>
           <VisitorProvider>
-            <main className="min-w-[320px]">{children}</main>
+            <main className="min-w-[320px] min-h-screen">{children}</main>
           </VisitorProvider>
         </Error>
       </body>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,21 +1,36 @@
+import { ArrowLeft } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Custom404() {
   return (
-    <div className="w-full h-screen flex items-center flex-col flex-wrap justify-center">
+    <div className="w-full min-h-screen flex items-center flex-col justify-center gap-6 px-6">
       <Image
         src={"/not-found.webp"}
         priority
-        height={300}
-        width={320}
+        height={200}
+        width={220}
         sizes="auto"
         alt="not-found"
+        className="opacity-80"
       />
 
-      <h1 className="font-semibold mt-[24px] text-[16px]">
-        요청하신 페이지를 찾을 수 없습니다.
-      </h1>
-      <h2>주소가 맞는지 다시 한 번 확인 부탁드려요!</h2>
+      <div className="text-center">
+        <h1 className="font-bold text-xl mb-2 text-foreground">
+          페이지를 찾을 수 없습니다
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          요청하신 주소가 맞는지 다시 한 번 확인해주세요.
+        </p>
+      </div>
+
+      <Link
+        href="/"
+        className="inline-flex items-center gap-2 text-sm text-brand-cyan hover:text-brand-cyan/80 transition-colors"
+      >
+        <ArrowLeft size={14} />
+        홈으로 돌아가기
+      </Link>
     </div>
   );
 }

--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -1,35 +1,36 @@
+import Navigator from "@/components/common/navigator";
 import { CAROUSEL_ITEMS } from "@/components/travel/contents/image-carousel/constant";
 import ImageCarousel from "@/components/travel/contents/image-carousel/image-carousel";
 import NewPosts from "@/components/travel/contents/new-posts";
 import Player from "@/components/travel/contents/player";
 import TripPosts from "@/components/travel/contents/trip-posts";
-import Header from "@/components/travel/header";
 
 export default async function Travel() {
   const newImages = [...CAROUSEL_ITEMS];
 
-  // const base64s = CAROUSEL_ITEMS.map(async (item) => {
-  //   const buffer = await readFile(path.join("./public", item.imageUrl));
-
-  //   const { base64 } = await getPlaiceholder(buffer, { size: 10 });
-  //   return { ...item, blurDataURL: base64 };
-  // });
-
-  // const values = await Promise.all(base64s);
-
-  // values.forEach((value, idx) => {
-  //   newImages[idx] = value;
-  // });
-
   return (
-    <div className="w-full grid grid-cols-1 px-[16px] py-[32px]">
-      <Header />
-      <div className="relative mt-[20px] grid grid-cols-1 gap-y-[12px] w-full">
-        <Player />
-        <ImageCarousel images={newImages} />
-        <NewPosts />
-        <TripPosts />
-        {/* <WorldMap /> */}
+    <div className="min-h-screen">
+      <Navigator />
+      <div className="max-w-5xl mx-auto px-6 py-8">
+        {/* Travel Hero */}
+        <div className="mb-10">
+          <p className="text-brand-amber text-sm font-medium mb-2 tracking-wide">
+            TRAVEL LOG
+          </p>
+          <h1 className="text-3xl md:text-4xl font-bold mb-3">
+            여행의 <span className="text-gradient">기록</span>
+          </h1>
+          <p className="text-muted-foreground max-w-lg">
+            세계 곳곳을 여행하며 보고, 느끼고, 경험한 것들을 담은 공간입니다.
+          </p>
+        </div>
+
+        <div className="relative grid grid-cols-1 gap-y-8 w-full">
+          <Player />
+          <ImageCarousel images={newImages} />
+          <NewPosts />
+          <TripPosts />
+        </div>
       </div>
     </div>
   );

--- a/src/app/videos/layout.tsx
+++ b/src/app/videos/layout.tsx
@@ -6,7 +6,7 @@ const VideoLayout = ({
   children: React.ReactNode;
 }>) => {
   return (
-    <div className="w-full h-full bg-gray-950 text-white">
+    <div className="w-full min-h-screen">
       <Navigator />
       {children}
     </div>

--- a/src/app/videos/page.tsx
+++ b/src/app/videos/page.tsx
@@ -2,7 +2,7 @@ import Video from "@/components/videos";
 
 const Videos = () => {
   return (
-    <div className="bg-gray-950 h-[calc(100vh-84px)]">
+    <div className="min-h-[calc(100vh-60px)] flex items-center justify-center p-6">
       <Video />
     </div>
   );

--- a/src/components/climbing/card.tsx
+++ b/src/components/climbing/card.tsx
@@ -1,8 +1,8 @@
-import { motion } from "framer-motion";
+"use client";
+
+import { MapPin } from "lucide-react";
 import Image from "next/image";
 import { FC } from "react";
-
-import { Card, CardContent, CardFooter, CardHeader } from "../ui/card";
 
 interface ClimbingCardProps {
   imageUrl?: string;
@@ -12,26 +12,28 @@ interface ClimbingCardProps {
 
 const ClimbingCard: FC<ClimbingCardProps> = ({ imageUrl, title, subTitle }) => {
   return (
-    <motion.div>
-      <Card className="w-[380px] h-fit">
-        {/* 이름 */}
-        <CardHeader className="font-medium text-[15px]">{title}</CardHeader>
-        {/* 이미지 */}
-        {imageUrl && (
-          <CardContent className="w-full">
-            <Image
-              width={300}
-              height={100}
-              src={imageUrl}
-              alt={title}
-              className="w-full h-[180px] object-cover bg-gray-50"
-            />
-          </CardContent>
+    <div className="w-[340px] rounded-xl overflow-hidden bg-surface-2 border border-border hover:border-border/80 transition-all group">
+      {imageUrl && (
+        <div className="relative w-full h-[160px] overflow-hidden">
+          <Image
+            width={340}
+            height={160}
+            src={imageUrl}
+            alt={title}
+            className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        </div>
+      )}
+      <div className="p-4">
+        <h3 className="font-semibold text-foreground mb-2">{title}</h3>
+        {subTitle && (
+          <p className="text-xs text-muted-foreground flex items-start gap-1.5">
+            <MapPin size={12} className="shrink-0 mt-0.5" />
+            {subTitle}
+          </p>
         )}
-        {/* 주소 */}
-        <CardFooter className="text-[13px]">{subTitle}</CardFooter>
-      </Card>
-    </motion.div>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/common/navigator.tsx
+++ b/src/components/common/navigator.tsx
@@ -1,16 +1,85 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Compass, Mountain, Pencil, Play, Plane } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV_ITEMS = [
+  { href: "/travel", label: "Travel", icon: Plane, adminOnly: false },
+  { href: "/videos", label: "Videos", icon: Play, adminOnly: false },
+  { href: "/climbing", label: "Climbing", icon: Mountain, adminOnly: false },
+  { href: "/write", label: "Write", icon: Pencil, adminOnly: true },
+] as const;
+
+const isDevMode = process.env.NODE_ENV === "development";
 
 const Navigator = () => {
+  const pathname = usePathname() ?? "";
+
   return (
-    <div className="w-full z-10 sticky top-0 flex items-center justify-between p-[16px] bg-inherit">
-      <Link href="/" className="flex items-center gap-x-[6px]">
-        <div className="border border-gray-200 shadow-md rounded-full size-fit cursor-pointer">
-          <Image src="/profile.png" alt="thumbnail" width={50} height={50} />
+    <motion.header
+      initial={{ y: -20, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{ duration: 0.4 }}
+      className="sticky top-0 z-50 w-full glass"
+    >
+      <nav className="max-w-5xl mx-auto flex items-center justify-between px-6 py-3">
+        {/* Logo */}
+        <Link href="/" className="flex items-center gap-3 group">
+          <div className="relative overflow-hidden rounded-full ring-2 ring-border group-hover:ring-primary transition-all duration-300">
+            <Image
+              src="/profile.png"
+              alt="Supin"
+              width={36}
+              height={36}
+              className="object-cover"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-sm text-foreground tracking-tight">
+              supin
+            </span>
+            <span className="font-pixel text-[8px] text-brand-cyan tracking-wider">
+              .log
+            </span>
+          </div>
+        </Link>
+
+        {/* Nav Links */}
+        <div className="flex items-center gap-1">
+          {NAV_ITEMS.filter((item) => !item.adminOnly || isDevMode).map(({ href, label, icon: Icon }) => {
+            const isActive =
+              pathname === href || pathname.startsWith(href + "/");
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={`
+                  relative flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium transition-all duration-200
+                  ${
+                    isActive
+                      ? "text-primary bg-primary/10"
+                      : "text-muted-foreground hover:text-foreground hover:bg-secondary"
+                  }
+                `}
+              >
+                <Icon size={14} />
+                <span className="hidden sm:inline">{label}</span>
+                {isActive && (
+                  <motion.div
+                    layoutId="nav-indicator"
+                    className="absolute bottom-0 left-2 right-2 h-0.5 bg-primary rounded-full"
+                    transition={{ type: "spring", stiffness: 400, damping: 30 }}
+                  />
+                )}
+              </Link>
+            );
+          })}
         </div>
-        <span className="text-inherit">{"supin'log"}</span>
-      </Link>
-    </div>
+      </nav>
+    </motion.header>
   );
 };
 

--- a/src/components/common/post-card.tsx
+++ b/src/components/common/post-card.tsx
@@ -4,8 +4,6 @@ import Image from "next/image";
 import Link from "next/link";
 import { FC } from "react";
 
-import { Card, CardContent, CardFooter } from "../ui/card";
-
 const DEFAULT_BLUR_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO8Vw8AAkEBX6r220kAAAAASUVORK5CYII=" as const;
 
@@ -19,27 +17,27 @@ interface PostCardProps {
 const PostCard: FC<PostCardProps> = ({ id, imageUrl, title, subTitle }) => {
   return (
     <Link href={`/posts/${id}`}>
-      <Card className="w-[340px] hover:cursor-pointer hover:-translate-y-1.5">
-        <CardContent className="w-full grid grid-cols-1 gap-y-[12px] px-0 pb-0">
-          <div className="relative w-full h-[150px]">
-            <Image
-              src={imageUrl}
-              alt="thumbnail"
-              sizes="140px"
-              fill
-              placeholder="blur"
-              blurDataURL={DEFAULT_BLUR_DATA_URL}
-              className="rounded-t-[12px]"
-            />
-          </div>
-          <span className="px-[16px] font-semibold text-[18px]">{title}</span>
-        </CardContent>
-        {subTitle && (
-          <CardFooter className="px-[16px] mt-[8px] text-gray-600">
-            {subTitle}
-          </CardFooter>
-        )}
-      </Card>
+      <div className="w-[340px] rounded-xl overflow-hidden bg-surface-2 border border-border hover:border-border/80 hover:-translate-y-1 transition-all duration-200 cursor-pointer group">
+        <div className="relative w-full h-[150px] overflow-hidden">
+          <Image
+            src={imageUrl}
+            alt="thumbnail"
+            sizes="340px"
+            fill
+            placeholder="blur"
+            blurDataURL={DEFAULT_BLUR_DATA_URL}
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        </div>
+        <div className="p-4">
+          <h3 className="font-semibold text-foreground text-base mb-1">
+            {title}
+          </h3>
+          {subTitle && (
+            <p className="text-sm text-muted-foreground">{subTitle}</p>
+          )}
+        </div>
+      </div>
     </Link>
   );
 };

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -1,6 +1,6 @@
-export { ScrollSection } from "./scroll-section";
-export { PixelTyping } from "./pixel-typing";
-export { PixelProgress } from "./pixel-progress";
+export { FloatingElements } from "./floating-elements";
 export { PixelAvatar } from "./pixel-avatar";
 export { PixelIcon } from "./pixel-icon";
-export { FloatingElements } from "./floating-elements";
+export { PixelProgress } from "./pixel-progress";
+export { PixelTyping } from "./pixel-typing";
+export { ScrollSection } from "./scroll-section";

--- a/src/components/home/main.tsx
+++ b/src/components/home/main.tsx
@@ -1,89 +1,415 @@
 "use client";
 
-import { motion, useScroll, useTransform } from "framer-motion";
-import { useRef } from "react";
-
-import { PixelIcon } from "@/components/home";
+import { motion } from "framer-motion";
 import {
-  AboutSection,
-  FavoritesSection,
-  HeroSection,
-  ProjectsSection,
-  TravelCTASection,
-} from "@/components/home/sections";
-import { SOCIAL_LINKS } from "@/constant/home-data";
+  ArrowRight,
+  Briefcase,
+  Code2,
+  ExternalLink,
+  Github,
+  MapPin,
+  Plane,
+} from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+
+import {
+  PROJECTS,
+  SKILLS,
+  SOCIAL_LINKS,
+  TRAVEL_DESTINATIONS,
+} from "@/constant/home-data";
+
+const fadeInUp = {
+  hidden: { opacity: 0, y: 30 },
+  visible: { opacity: 1, y: 0 },
+};
+
+const stagger = {
+  visible: { transition: { staggerChildren: 0.1 } },
+};
 
 export default function HomePage() {
-  const containerRef = useRef(null);
-  const { scrollYProgress } = useScroll({ target: containerRef });
-  const progressWidth = useTransform(scrollYProgress, [0, 1], ["0%", "100%"]);
-
   return (
-    <div ref={containerRef} className="bg-slate-900 text-white font-pixel">
-      {/* 스크롤 프로그레스 바 */}
-      <motion.div
-        style={{ width: progressWidth }}
-        className="fixed top-0 left-0 h-2 bg-gradient-to-r from-cyan-400 via-pink-500 to-yellow-400 z-50"
-      />
+    <div className="min-h-screen">
+      {/* Hero Section */}
+      <section className="relative min-h-[90vh] flex items-center justify-center overflow-hidden">
+        {/* 배경 그라데이션 */}
+        <div className="absolute inset-0">
+          <div className="absolute inset-0 bg-gradient-to-br from-background via-background to-surface-2" />
+          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-brand-cyan/5 rounded-full blur-3xl" />
+          <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-brand-violet/5 rounded-full blur-3xl" />
+        </div>
 
-      {/* 좌측 고정 소셜 링크 */}
-      <div className="fixed left-4 top-1/2 -translate-y-1/2 z-40 hidden md:flex flex-col gap-4">
-        {SOCIAL_LINKS.map((link, i) => (
-          <motion.a
-            key={link.label}
-            href={link.href}
-            initial={{ x: -50, opacity: 0 }}
-            animate={{ x: 0, opacity: 1 }}
-            transition={{ delay: 1 + i * 0.1 }}
-            whileHover={{ scale: 1.2, x: 4 }}
-            className="w-10 h-10 bg-slate-800 border-2 border-slate-600 flex items-center justify-center hover:border-blue-500 transition-colors"
-            title={link.label}
+        <div className="relative z-10 max-w-4xl mx-auto px-6 text-center">
+          <motion.div
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ duration: 0.6 }}
           >
-            <PixelIcon
-              name={link.icon}
-              size="md"
-              className="text-slate-400 hover:text-blue-400"
-            />
-          </motion.a>
-        ))}
-        <div className="w-px h-20 bg-slate-600 mx-auto" />
-      </div>
+            {/* 프로필 이미지 */}
+            <div className="relative inline-block mb-8">
+              <div className="w-28 h-28 rounded-full overflow-hidden ring-2 ring-border ring-offset-4 ring-offset-background mx-auto">
+                <Image
+                  src="/profile.png"
+                  alt="Supin"
+                  width={112}
+                  height={112}
+                  className="object-cover"
+                />
+              </div>
+            </div>
 
-      <HeroSection />
-      <AboutSection />
-      <ProjectsSection />
-      <FavoritesSection />
-      <TravelCTASection />
+            {/* 인사 */}
+            <motion.p
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2 }}
+              className="text-muted-foreground text-sm mb-3 tracking-wide"
+            >
+              Frontend Developer
+            </motion.p>
 
-      {/* 푸터 */}
-      <footer className="border-t-4 border-slate-700 p-8">
-        <div className="max-w-4xl mx-auto">
-          {/* 모바일 소셜 링크 */}
-          <div className="flex justify-center gap-4 mb-6 md:hidden">
+            <motion.h1
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3 }}
+              className="text-4xl md:text-6xl font-bold mb-4 tracking-tight"
+            >
+              <span className="text-gradient">Kim Supin</span>
+            </motion.h1>
+
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.4 }}
+              className="text-lg md:text-xl text-muted-foreground max-w-xl mx-auto mb-8 leading-relaxed"
+            >
+              코드로 재미있는 경험을 만들고,
+              <br />
+              여행하며 보고 느낀 것들을 기록합니다.
+            </motion.p>
+
+            {/* CTA 버튼들 */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.5 }}
+              className="flex items-center justify-center gap-3 flex-wrap"
+            >
+              <Link
+                href="/travel"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-foreground rounded-lg font-medium text-sm hover:opacity-90 transition-opacity"
+              >
+                <Plane size={16} />
+                Travel Blog
+              </Link>
+              <a
+                href="https://github.com/SUPINKIM"
+                target="_blank"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-secondary text-secondary-foreground rounded-lg font-medium text-sm hover:bg-secondary/80 transition-colors"
+              >
+                <Github size={16} />
+                GitHub
+              </a>
+            </motion.div>
+
+            {/* 스크롤 힌트 */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 1 }}
+              className="mt-16"
+            >
+              <motion.div
+                animate={{ y: [0, 8, 0] }}
+                transition={{ duration: 2, repeat: Infinity }}
+                className="w-5 h-8 rounded-full border-2 border-muted-foreground/30 flex items-start justify-center p-1 mx-auto"
+              >
+                <motion.div className="w-1 h-2 bg-muted-foreground/50 rounded-full" />
+              </motion.div>
+            </motion.div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* About Section */}
+      <section className="py-24 px-6">
+        <motion.div
+          variants={stagger}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: "-100px" }}
+          className="max-w-4xl mx-auto"
+        >
+          <motion.div variants={fadeInUp} className="mb-12">
+            <p className="text-brand-cyan text-sm font-medium mb-2 tracking-wide">
+              ABOUT
+            </p>
+            <h2 className="text-3xl font-bold mb-6">
+              안녕하세요, <span className="text-gradient">수빈</span>입니다
+            </h2>
+            <p className="text-muted-foreground leading-relaxed max-w-2xl">
+              5년차 프론트엔드 개발자로, 현재{" "}
+              <span className="text-foreground font-medium">Levit</span>에서{" "}
+              <span className="text-foreground font-medium">Alwayz 앱</span>과
+              농장 시뮬레이션 게임{" "}
+              <span className="text-foreground font-medium">올팜</span>을
+              개발하고 있어요. 사용자에게 즐거운 경험을 전달하는 서비스를 만드는
+              걸 좋아합니다.
+            </p>
+          </motion.div>
+
+          {/* 현재 직장 */}
+          <motion.div
+            variants={fadeInUp}
+            className="flex items-center gap-3 mb-10 p-4 rounded-xl bg-surface-2 border border-border w-fit"
+          >
+            <Briefcase size={18} className="text-brand-cyan" />
+            <div>
+              <p className="text-sm font-medium">Levit - Alwayz</p>
+              <p className="text-xs text-muted-foreground">
+                Frontend Developer / 2021 ~
+              </p>
+            </div>
+            <div className="w-2 h-2 rounded-full bg-brand-emerald animate-pulse ml-2" />
+          </motion.div>
+
+          {/* Skills */}
+          <motion.div variants={fadeInUp} className="space-y-4">
+            <p className="text-sm font-medium text-muted-foreground mb-4 flex items-center gap-2">
+              <Code2 size={14} />
+              TECH STACK
+            </p>
+            {SKILLS.map((skill) => (
+              <div key={skill.name} className="space-y-1.5">
+                <div className="flex justify-between text-sm">
+                  <span className="text-foreground font-medium">
+                    {skill.name}
+                  </span>
+                  <span className="text-muted-foreground">{skill.value}%</span>
+                </div>
+                <div className="h-1.5 bg-surface-3 rounded-full overflow-hidden">
+                  <motion.div
+                    initial={{ width: 0 }}
+                    whileInView={{ width: `${skill.value}%` }}
+                    transition={{ duration: 1, ease: "easeOut" }}
+                    viewport={{ once: true }}
+                    className={`h-full rounded-full ${skill.color}`}
+                  />
+                </div>
+              </div>
+            ))}
+          </motion.div>
+        </motion.div>
+      </section>
+
+      {/* Projects Section */}
+      <section className="py-24 px-6 bg-surface-1">
+        <motion.div
+          variants={stagger}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: "-100px" }}
+          className="max-w-4xl mx-auto"
+        >
+          <motion.div variants={fadeInUp} className="mb-12">
+            <p className="text-brand-violet text-sm font-medium mb-2 tracking-wide">
+              PROJECTS
+            </p>
+            <h2 className="text-3xl font-bold">만들어온 것들</h2>
+          </motion.div>
+
+          <div className="grid md:grid-cols-2 gap-4">
+            {PROJECTS.map((project) => (
+              <motion.div
+                key={project.name}
+                variants={fadeInUp}
+                whileHover={{ y: -4, transition: { duration: 0.2 } }}
+                className="group p-6 rounded-xl bg-surface-2 border border-border hover:border-brand-violet/30 transition-all duration-300 cursor-pointer"
+                onClick={() => {
+                  if (project.link === "#") return;
+                  window.open(project.link);
+                }}
+              >
+                <div className="flex items-start justify-between mb-3">
+                  <h3 className="font-semibold text-foreground group-hover:text-brand-violet transition-colors">
+                    {project.name}
+                  </h3>
+                  <span className="text-xs text-muted-foreground bg-surface-3 px-2 py-1 rounded">
+                    {project.year}
+                  </span>
+                </div>
+                <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+                  {project.desc}
+                </p>
+                <div className="flex items-center justify-between">
+                  <div className="flex gap-1.5">
+                    {project.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="text-[10px] font-medium text-brand-cyan bg-brand-cyan/10 px-2 py-0.5 rounded"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                  {project.link !== "#" && (
+                    <ExternalLink
+                      size={14}
+                      className="text-muted-foreground group-hover:text-brand-violet transition-colors"
+                    />
+                  )}
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+      </section>
+
+      {/* Travel Destinations Section */}
+      <section className="py-24 px-6">
+        <motion.div
+          variants={stagger}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: "-100px" }}
+          className="max-w-4xl mx-auto"
+        >
+          <motion.div variants={fadeInUp} className="mb-12">
+            <p className="text-brand-amber text-sm font-medium mb-2 tracking-wide">
+              TRAVEL
+            </p>
+            <h2 className="text-3xl font-bold mb-4">
+              여행하며 기록하는 순간들
+            </h2>
+            <p className="text-muted-foreground">
+              지금까지 방문한 도시들. 각 여행의 이야기를 블로그에 담고 있어요.
+            </p>
+          </motion.div>
+
+          {/* 여행지 그리드 */}
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
+            {TRAVEL_DESTINATIONS.map((dest) => (
+              <motion.div
+                key={dest.country}
+                variants={fadeInUp}
+                whileHover={{ scale: 1.02, transition: { duration: 0.2 } }}
+                className="relative group rounded-xl overflow-hidden aspect-[4/3] cursor-pointer"
+              >
+                <Image
+                  src={dest.image}
+                  alt={dest.country}
+                  fill
+                  className="object-cover transition-transform duration-500 group-hover:scale-110"
+                  sizes="(max-width: 768px) 50vw, 33vw"
+                />
+                <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+                <div className="absolute bottom-3 left-3 flex items-center gap-2">
+                  <span className="text-lg">{dest.emoji}</span>
+                  <span className="text-white text-sm font-medium">
+                    {dest.country}
+                  </span>
+                </div>
+                <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <MapPin size={16} className="text-white" />
+                </div>
+              </motion.div>
+            ))}
+          </div>
+
+          {/* Travel Blog CTA */}
+          <motion.div variants={fadeInUp} className="text-center">
+            <Link
+              href="/travel"
+              className="inline-flex items-center gap-2 text-sm text-brand-cyan hover:text-brand-cyan/80 transition-colors font-medium"
+            >
+              모든 여행 기록 보러가기
+              <ArrowRight size={16} />
+            </Link>
+          </motion.div>
+        </motion.div>
+      </section>
+
+      {/* Interests Section - 간결한 포인트 */}
+      <section className="py-24 px-6 bg-surface-1">
+        <motion.div
+          variants={stagger}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: "-100px" }}
+          className="max-w-4xl mx-auto"
+        >
+          <motion.div variants={fadeInUp} className="mb-12">
+            <p className="text-brand-rose text-sm font-medium mb-2 tracking-wide">
+              BEYOND CODE
+            </p>
+            <h2 className="text-3xl font-bold">코딩 외의 이야기</h2>
+          </motion.div>
+
+          <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
+            {[
+              {
+                emoji: "✈️",
+                title: "여행",
+                desc: "새로운 곳을 탐험하는 것",
+                accent: "brand-cyan",
+              },
+              {
+                emoji: "🎮",
+                title: "게임",
+                desc: "픽셀 아트 & 인디 게임",
+                accent: "brand-violet",
+              },
+              {
+                emoji: "💻",
+                title: "코딩",
+                desc: "아이디어를 현실로",
+                accent: "brand-amber",
+              },
+              {
+                emoji: "📚",
+                title: "책",
+                desc: "틈틈이, 자주, 많이 읽기",
+                accent: "brand-rose",
+              },
+            ].map((item) => (
+              <motion.div
+                key={item.title}
+                variants={fadeInUp}
+                className="p-5 rounded-xl bg-surface-2 border border-border text-center hover:border-border/80 transition-colors"
+              >
+                <div className="text-3xl mb-3">{item.emoji}</div>
+                <h3 className="font-medium text-sm mb-1">{item.title}</h3>
+                <p className="text-xs text-muted-foreground">{item.desc}</p>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+      </section>
+
+      {/* Footer */}
+      <footer className="py-12 px-6 border-t border-border">
+        <div className="max-w-4xl mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-sm">supin</span>
+            <span className="font-pixel text-[8px] text-brand-cyan">.log</span>
+          </div>
+
+          <div className="flex items-center gap-4">
             {SOCIAL_LINKS.map((link) => (
               <a
                 key={link.label}
                 href={link.href}
                 target="_blank"
-                className="w-10 h-10 bg-slate-800 border-2 border-slate-600 flex items-center justify-center hover:border-cyan-400 transition-colors"
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
               >
-                <PixelIcon
-                  name={link.icon}
-                  size="md"
-                  className="text-slate-400"
-                />
+                {link.label}
               </a>
             ))}
           </div>
 
-          <div className="text-center">
-            <div className="flex items-center justify-center gap-2 mb-2">
-              <PixelIcon name="heart" size="sm" className="text-pink-400" />
-              <span className="text-xs text-slate-600">MADE WITH LOVE</span>
-              <PixelIcon name="heart" size="sm" className="text-pink-400" />
-            </div>
-            <p className="text-xs text-slate-600">© 2025 SUPIN</p>
-          </div>
+          <p className="text-xs text-muted-foreground">&copy; 2025 Supin Kim</p>
         </div>
       </footer>
     </div>

--- a/src/components/home/pixel-avatar.tsx
+++ b/src/components/home/pixel-avatar.tsx
@@ -2,7 +2,11 @@
 
 import { motion } from "framer-motion";
 
-import { AVATAR_PIXELS } from "@/constant/home-data";
+const AVATAR_PIXELS = [
+  0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1,
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0,
+  1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0,
+] as const;
 
 interface PixelAvatarProps {
   size?: "sm" | "md" | "lg";

--- a/src/components/home/sections/about-section.tsx
+++ b/src/components/home/sections/about-section.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { PixelIcon, PixelProgress, ScrollSection } from "@/components/home";
-import { SECTION_ICONS, SKILLS } from "@/constant/home-data";
+import { SKILLS } from "@/constant/home-data";
+
+const SECTION_ICONS = {
+  about: "user",
+  projects: "gamepad",
+  favorites: "heart",
+  travel: "plane",
+} as const;
 
 export function AboutSection() {
   return (
@@ -72,7 +79,6 @@ export function AboutSection() {
                 label={skill.name}
                 value={skill.value}
                 color={skill.color}
-                icon={skill.icon}
               />
             ))}
           </div>

--- a/src/components/home/sections/favorites-section.tsx
+++ b/src/components/home/sections/favorites-section.tsx
@@ -3,7 +3,14 @@
 import { motion } from "framer-motion";
 
 import { PixelIcon, ScrollSection } from "@/components/home";
-import { FAVORITES, SECTION_ICONS } from "@/constant/home-data";
+import { FAVORITES } from "@/constant/home-data";
+
+const SECTION_ICONS = {
+  about: "user",
+  projects: "gamepad",
+  favorites: "heart",
+  travel: "plane",
+} as const;
 
 export function FavoritesSection() {
   return (

--- a/src/components/home/sections/hero-section.tsx
+++ b/src/components/home/sections/hero-section.tsx
@@ -8,7 +8,14 @@ import {
   PixelIcon,
   PixelTyping,
 } from "@/components/home";
-import { FLOATING_HERO_ICONS } from "@/constant/home-data";
+
+const FLOATING_HERO_ICONS = [
+  { icon: "star", position: { top: "5rem", left: "5rem" }, duration: 3 },
+  { icon: "startups", position: { top: "10rem", right: "8rem" }, duration: 2.5, direction: "down" as const },
+  { icon: "save", position: { bottom: "10rem", left: "8rem" }, duration: 2 },
+  { icon: "heart", position: { top: "15rem", left: "20rem" }, duration: 2.8 },
+  { icon: "comment-quote", position: { bottom: "15rem", right: "15rem" }, duration: 3.2, direction: "down" as const },
+] as const;
 
 export function HeroSection() {
   return (

--- a/src/components/home/sections/projects-section.tsx
+++ b/src/components/home/sections/projects-section.tsx
@@ -3,7 +3,14 @@
 import { motion } from "framer-motion";
 
 import { PixelIcon, ScrollSection } from "@/components/home";
-import { PROJECTS, SECTION_ICONS } from "@/constant/home-data";
+import { PROJECTS } from "@/constant/home-data";
+
+const SECTION_ICONS = {
+  about: "user",
+  projects: "gamepad",
+  favorites: "heart",
+  travel: "plane",
+} as const;
 
 export function ProjectsSection() {
   return (
@@ -49,7 +56,7 @@ export function ProjectsSection() {
               <div className="flex items-start justify-between mb-4">
                 <div className="w-12 h-12 bg-slate-700 border-2 border-pink-300 flex items-center justify-center">
                   <PixelIcon
-                    name={project.icon}
+                    name="gamepad"
                     size="lg"
                     className="text-pink-400"
                   />

--- a/src/components/home/sections/travel-cta-section.tsx
+++ b/src/components/home/sections/travel-cta-section.tsx
@@ -5,7 +5,17 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { PixelIcon, ScrollSection } from "@/components/home";
-import { BG_ICONS, SECTION_ICONS } from "@/constant/home-data";
+
+const BG_ICONS = [
+  "plane", "globe-americas-solid", "globe", "retro-camera", "plane-solid", "location-pin-solid",
+] as const;
+
+const SECTION_ICONS = {
+  about: "user",
+  projects: "gamepad",
+  favorites: "heart",
+  travel: "plane",
+} as const;
 
 // 고정된 위치 배열
 const ICON_POSITIONS = [

--- a/src/components/posts/post-title.tsx
+++ b/src/components/posts/post-title.tsx
@@ -32,18 +32,18 @@ const PostTitle: FC<PostTitleProps> = ({ title, thumbnail }) => {
   }, []);
 
   return (
-    <div className="w-full">
+    <div className="w-full max-w-[800px]">
       <div
         ref={titleRef}
         className={cn(
-          "relative flex items-center justify-center z-1 w-full rounded-[12px]",
-          thumbnail ? "sm:h-[280px] h-[160px]" : "h-fit"
+          "relative flex items-center justify-center z-[1] w-full rounded-xl overflow-hidden",
+          thumbnail ? "sm:h-[280px] h-[160px]" : "h-fit py-6"
         )}
       >
         <p
           className={cn(
-            "text-[24px] sm:text-[28px] font-medium z-[1]",
-            thumbnail ? "text-white" : "text-black"
+            "text-2xl sm:text-3xl font-bold z-[1] text-center px-4",
+            thumbnail ? "text-white" : "text-foreground"
           )}
         >
           {title}
@@ -54,14 +54,14 @@ const PostTitle: FC<PostTitleProps> = ({ title, thumbnail }) => {
               src={thumbnail}
               alt="header-image"
               fill
-              className="object-fill opacity-40 rounded-[12px]"
+              className="object-cover opacity-40 rounded-xl"
             />
-            <div className="size-full bg-gray-400 rounded-[12px]" />
+            <div className="absolute inset-0 bg-background/60 rounded-xl" />
           </div>
         )}
       </div>
       {!isVisible && (
-        <div className="fixed z-10 font-medium text-[14px] right-6 top-[33px] sm:left-[160px]">
+        <div className="fixed z-10 font-medium text-sm right-6 top-[18px] text-foreground">
           {title}
         </div>
       )}

--- a/src/components/travel/contents/new-posts/card.tsx
+++ b/src/components/travel/contents/new-posts/card.tsx
@@ -3,23 +3,22 @@
 import { motion } from "framer-motion";
 import { FC } from "react";
 
-import { Card, CardContent } from "@/components/ui/card";
-
 interface PostCardProps {
   title: string;
 }
 
 const PostCard: FC<PostCardProps> = ({ title }) => {
   return (
-    <motion.div initial={{ opacity: 0 }} whileInView={{ opacity: 1 }}>
-      <Card className="flex items-center justify-center w-[160px] py-[12px]">
-        <CardContent className="flex gap-x-[8px] flex-wrap items-center justify-center shrink-0 p-0 h-[48px]">
-          <div className="flex items-center justify-center size-[14px] rounded-full text-[10px] bg-red-500 text-white">
-            N
-          </div>
-          <p>{title}</p>
-        </CardContent>
-      </Card>
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      whileHover={{ y: -2 }}
+      className="flex items-center gap-2 px-4 py-3 rounded-lg bg-surface-2 border border-border hover:border-brand-cyan/30 transition-all cursor-pointer"
+    >
+      <div className="flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold bg-brand-rose text-white shrink-0">
+        N
+      </div>
+      <p className="text-sm font-medium">{title}</p>
     </motion.div>
   );
 };

--- a/src/components/travel/contents/new-posts/index.tsx
+++ b/src/components/travel/contents/new-posts/index.tsx
@@ -15,16 +15,18 @@ const NewPosts = async () => {
   await getPostLists();
 
   return (
-    <div className="pt-[6px] pb-[10px] grid grid-cols-1 gap-y-[16px]">
-      <p className="font-medium text-[16px]">최신 포스트가 올라왔어요! ✍️</p>
+    <div className="py-4">
+      <div className="flex items-center gap-2 mb-4">
+        <div className="w-1.5 h-1.5 rounded-full bg-brand-rose animate-pulse" />
+        <h2 className="text-lg font-semibold">Latest Posts</h2>
+      </div>
 
-      <div className="flex flex-wrap gap-[12px]">
+      <div className="flex flex-wrap gap-3">
         {posts.map((post) => (
           <Link key={post.id} href={`posts/${post.id}`} className="w-fit">
             <PostCard title={post.title} />
           </Link>
         ))}
-        {/* <Link href="posts/3" className="w-fit"></Link> */}
       </div>
     </div>
   );

--- a/src/components/travel/contents/player/index.tsx
+++ b/src/components/travel/contents/player/index.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { Pause, Play } from "lucide-react";
-import Image from "next/image";
-import { useEffect, useRef } from "react";
+import { Music, Pause, Play } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 import { CustomAudioContext } from "./model";
 
 const Player = () => {
   const audioRef = useRef<HTMLAudioElement>(null);
   const audiContext = useRef<CustomAudioContext>();
+  const [isPlaying, setIsPlaying] = useState(false);
 
   useEffect(() => {
     if (!audioRef.current) return;
@@ -17,51 +17,39 @@ const Player = () => {
 
   const handleClickPlay = () => {
     audiContext.current?.play();
+    setIsPlaying(true);
   };
 
   const handleClickStop = () => {
     audiContext.current?.pause();
+    setIsPlaying(false);
   };
 
   return (
-    <div className="fixed bottom-4 right-8 z-[999]">
-      <div className="flex justify-center flex-col items-center gap-[8px]">
+    <div className="fixed bottom-6 right-6 z-[999]">
+      <div className="glass rounded-2xl p-3 flex items-center gap-3 glow-sm">
         <div className="relative">
-          <Image
-            className="rounded-[20px]"
-            src="/player/christmas.png"
-            alt="santa"
-            width={120}
-            height={120}
-          />
-          <div className="absolute -top-[20px] -right-[20px]">
-            <Image
-              src="/player/lp_record.webp"
-              alt="lp_player"
-              width={60}
-              height={60}
-              className="animate-spin"
-            />
+          <div
+            className={`w-10 h-10 rounded-full bg-surface-3 flex items-center justify-center ${isPlaying ? "animate-spin" : ""}`}
+            style={{ animationDuration: "3s" }}
+          >
+            <Music size={16} className="text-brand-cyan" />
           </div>
         </div>
         <audio
           ref={audioRef}
           src="/player/We_Wish_You_a_Merry_Christmas.wav"
-          autoPlay
         />
-        {/* Play / Pause button only */}
-        <div className="flex items-center justify-center">
-          <button
-            className="inline-flex h-16 w-[120px] items-center justify-center rounded-[20px] bg-red-400/80 text-slate-950 shadow-lg shadow-red-500/40 hover:bg-red-300 transition-colors"
-            aria-label={"player"}
-          >
-            <Pause onClick={handleClickStop} className="h-7 w-7" />
-            <Play
-              onClick={handleClickPlay}
-              className="h-7 w-7 translate-x-[1px]"
-            />
-          </button>
-        </div>
+        <button
+          onClick={isPlaying ? handleClickStop : handleClickPlay}
+          className="w-9 h-9 rounded-full bg-brand-cyan/20 hover:bg-brand-cyan/30 flex items-center justify-center transition-colors"
+        >
+          {isPlaying ? (
+            <Pause size={14} className="text-brand-cyan" />
+          ) : (
+            <Play size={14} className="text-brand-cyan translate-x-[1px]" />
+          )}
+        </button>
       </div>
     </div>
   );

--- a/src/components/travel/contents/trip-posts/index.tsx
+++ b/src/components/travel/contents/trip-posts/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Globe } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { ListByCountries } from "@/types/api/list_by_countries";
@@ -38,18 +39,22 @@ const TripPosts = () => {
   }, [country]);
 
   return (
-    <div className="py-[8px]">
-      <div className="py-[12px]">
-        <div className="flex gap-[8px] justify-between flex-wrap">
-          <TripPostSelect setCountry={setCountry} />
-        </div>
+    <div className="py-4">
+      <div className="flex items-center gap-2 mb-4">
+        <Globe size={16} className="text-brand-amber" />
+        <h2 className="text-lg font-semibold">Trip Posts</h2>
       </div>
-      <div className="flex pb-[8px] items-center min-[746px]:justify-start justify-center gap-x-[18px] w-full flex-wrap gap-y-[24px]">
+
+      <div className="mb-6">
+        <TripPostSelect setCountry={setCountry} />
+      </div>
+
+      <div className="flex pb-4 items-center min-[746px]:justify-start justify-center gap-x-4 w-full flex-wrap gap-y-4">
         {isLoading ? (
           Array.from({ length: 3 }).map((_, index) => (
             <div
               key={index}
-              className="h-[270px] bg-gray-100 rounded-[24px] animate-pulse w-[340px]"
+              className="h-[270px] bg-surface-2 rounded-xl animate-pulse w-[340px]"
             />
           ))
         ) : (

--- a/src/components/travel/contents/trip-posts/trip-post-select.tsx
+++ b/src/components/travel/contents/trip-posts/trip-post-select.tsx
@@ -17,12 +17,16 @@ interface TripPostSelectProps {
 const TripPostSelect: FC<TripPostSelectProps> = ({ setCountry }) => {
   return (
     <Select onValueChange={(value) => setCountry(value as Countries)}>
-      <SelectTrigger className="max-w-[200px] h-[42px]">
-        <SelectValue placeholder="select the country..." />
+      <SelectTrigger className="max-w-[200px] h-10 bg-surface-2 border-border text-foreground">
+        <SelectValue placeholder="Select country..." />
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent className="bg-surface-2 border-border">
         {Object.values(Countries).map((country) => (
-          <SelectItem className="h-[36px]" key={country} value={country}>
+          <SelectItem
+            className="h-9 text-foreground hover:bg-surface-3 focus:bg-surface-3"
+            key={country}
+            value={country}
+          >
             {country}
           </SelectItem>
         ))}

--- a/src/components/travel/header/visitor.tsx
+++ b/src/components/travel/header/visitor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Eye } from "lucide-react";
 import { useEffect } from "react";
 
 import { useVisitorContext } from "@/hooks/visitor";
@@ -16,8 +17,9 @@ const Visitor = () => {
   }, [count, setCount]);
 
   return (
-    <div className="mr-[8px] shrink-0 text-[13px] bg-gray-100 rounded-[8px] p-[8px]">
-      <p>🫰 누적 방문자 수 : {count}</p>
+    <div className="inline-flex items-center gap-2 text-xs text-muted-foreground bg-surface-2 border border-border rounded-lg px-3 py-2">
+      <Eye size={12} />
+      <span>{count ?? "..."} visitors</span>
     </div>
   );
 };

--- a/src/components/videos/index.tsx
+++ b/src/components/videos/index.tsx
@@ -3,11 +3,11 @@ import { videos } from "./constant";
 
 const Video = () => {
   return (
-    <div className="bg-gray-800 max-w-[1000px] min-w-[360px] rounded-[8px] px-[24px] pt-[16px] pb-[32px] grid grid-cols-1 mx-auto">
-      <div className="pb-[16px] flex items-center gap-x-[6px]">
+    <div className="bg-surface-2 max-w-[1000px] min-w-[360px] rounded-xl border border-border px-6 pt-4 pb-8 grid grid-cols-1 mx-auto">
+      <div className="pb-4 flex items-center gap-x-2">
         <Buttons />
       </div>
-      <video autoPlay muted loop className="object-cover w-full">
+      <video autoPlay muted loop className="object-cover w-full rounded-lg">
         <source src={videos[0].src} type="video/mp4" />
       </video>
     </div>

--- a/src/constant/home-data.ts
+++ b/src/constant/home-data.ts
@@ -1,37 +1,37 @@
 export const SKILLS = [
-  { name: "React", value: 90, color: "bg-cyan-400", icon: "programming" },
-  { name: "TypeScript", value: 85, color: "bg-blue-500", icon: "programming" },
-  { name: "Tailwindcss", value: 80, color: "bg-white", icon: "code" },
+  { name: "React", value: 90, color: "bg-brand-cyan" },
+  { name: "TypeScript", value: 85, color: "bg-brand-violet" },
+  { name: "Tailwindcss", value: 80, color: "bg-brand-amber" },
 ] as const;
 
 export const PROJECTS = [
   {
-    icon: "seedlings-solid",
     name: "올팜",
     desc: "온라인으로 작물을 키워 실제로 받는 앱테크 서비스",
     year: "2025",
     link: "#",
+    tags: ["React", "TypeScript"],
   },
   {
-    icon: "finance",
-    name: "오늘의 운세",
-    desc: "카드 뽑기 게임",
-    year: "2025",
-    link: "https://supinkim.github.io/today-fortune/",
-  },
-  {
-    icon: "gaming",
-    name: "Christmas Scene",
-    desc: "Three.js 인터랙티브",
+    name: "Alwayz",
+    desc: "소셜 커머스 앱. React Native 기반 하이브리드 앱 내 웹뷰 서비스 개발",
     year: "2025",
     link: "#",
+    tags: ["React Native", "WebView"],
   },
   {
-    icon: "shopping-cart",
     name: "신상마켓",
-    desc: "B2B 동대문 도소매 패션 커머스 웹 개발",
+    desc: "B2B 동대문 도소매 패션 커머스. 장바구니, 주문/결제 시스템 등 핵심 커머스 기능 개발",
     year: "2023",
     link: "#",
+    tags: ["React", "Next.js"],
+  },
+  {
+    name: "오늘의 운세",
+    desc: "카드 뽑기 운세 게임 사이드 프로젝트",
+    year: "2025",
+    link: "https://supinkim.github.io/today-fortune/",
+    tags: ["React", "Canvas"],
   },
 ] as const;
 
@@ -43,52 +43,29 @@ export const FAVORITES = [
 ] as const;
 
 export const SOCIAL_LINKS = [
-  { icon: "globe", label: "Blog", href: "/travel" },
-  { icon: "github", label: "GitHub", href: "https://github.com/SUPINKIM" },
   {
-    icon: "linkedin",
-    label: "linkedin",
+    label: "GitHub",
+    href: "https://github.com/SUPINKIM",
+  },
+  {
+    label: "LinkedIn",
     href: "https://www.linkedin.com/in/supinkim",
   },
-] as const;
-
-export const AVATAR_PIXELS = [
-  0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0,
-  0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0,
-] as const;
-
-export const FLOATING_HERO_ICONS = [
-  { icon: "star", position: { top: "5rem", left: "5rem" }, duration: 3 },
   {
-    icon: "startups",
-    position: { top: "10rem", right: "8rem" },
-    duration: 2.5,
-    direction: "down" as const,
-  },
-  { icon: "save", position: { bottom: "10rem", left: "8rem" }, duration: 2 },
-  { icon: "heart", position: { top: "15rem", left: "20rem" }, duration: 2.8 },
-  {
-    icon: "comment-quote",
-    position: { bottom: "15rem", right: "15rem" },
-    duration: 3.2,
-    direction: "down" as const,
+    label: "Resume",
+    href: "https://my.surfit.io/w/1555709893",
   },
 ] as const;
 
-export const BG_ICONS = [
-  "plane",
-  "globe-americas-solid",
-  "globe",
-  "retro-camera",
-  "plane-solid",
-  "location-pin-solid",
+export const TRAVEL_DESTINATIONS = [
+  { country: "Australia", emoji: "🇦🇺", image: "/australia/opera_house.png" },
+  { country: "Japan", emoji: "🇯🇵", image: "/japan/japan1.png" },
+  { country: "England", emoji: "🇬🇧", image: "/london/london1.png" },
+  { country: "France", emoji: "🇫🇷", image: "/paris/paris1.png" },
+  { country: "Hong Kong", emoji: "🇭🇰", image: "/hongkong/hongkong1.png" },
+  {
+    country: "Kota Kinabalu",
+    emoji: "🇲🇾",
+    image: "/kota-kinabalu/kota1.png",
+  },
 ] as const;
-
-// 섹션 타이틀 아이콘
-export const SECTION_ICONS = {
-  about: "user",
-  projects: "gamepad",
-  favorites: "heart",
-  travel: "plane",
-} as const;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,6 +20,7 @@ const config = {
     extend: {
       fontFamily: {
         pixel: ["var(--font-pixel)", "cursive"],
+        sans: ["Inter", "system-ui", "sans-serif"],
       },
       colors: {
         border: "hsl(var(--border))",
@@ -55,6 +56,19 @@ const config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        // 브랜드 컬러
+        brand: {
+          cyan: "hsl(var(--brand-cyan))",
+          violet: "hsl(var(--brand-violet))",
+          amber: "hsl(var(--brand-amber))",
+          rose: "hsl(var(--brand-rose))",
+          emerald: "hsl(var(--brand-emerald))",
+        },
+        surface: {
+          1: "hsl(var(--surface-1))",
+          2: "hsl(var(--surface-2))",
+          3: "hsl(var(--surface-3))",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
@@ -70,10 +84,20 @@ const config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "fade-in": {
+          from: { opacity: "0", transform: "translateY(10px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        shimmer: {
+          "0%": { backgroundPosition: "-200% 0" },
+          "100%": { backgroundPosition: "200% 0" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "fade-in": "fade-in 0.5s ease-out forwards",
+        shimmer: "shimmer 2s linear infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary
홈페이지와 여행 페이지 사이의 디자인 단절을 해소하고, 다크 테마 기반의 세련된 통합 디자인 시스템으로 전면 리디자인
## Changes
### 디자인 시스템
- globals.css: 다크 네이비 기반 통합 컬러 토큰 (브랜드 컬러 5종, surface 레이어링, glass/glow 유틸리티)
- tailwind.config.ts: brand, surface 커스텀 컬러 + fade-in/shimmer 애니메이션 추가
### 공통 컴포넌트
- Navigator: 전 페이지 공통 glass 스타일 네비게이션 (active indicator, 로고에 font-pixel 포인트)
- Write 메뉴: NODE_ENV === "development" 일 때만 노출
- PostCard, ClimbingCard: 다크 테마 통합 스타일
### 홈페이지 (/)
- 세련된 포트폴리오 + 여행/관심사 허브로 전면 재구성
- 프로젝트 리스트: Alwayz 추가, Christmas Scene 제거, 신상마켓 설명 보강
### 여행 페이지 (/travel)
- 다크 테마 적용, Navigator 통합, 뮤직 플레이어 glass 스타일로 변경
### 서브 페이지
- Posts, Videos, Climbing, 404 모든 페이지 다크 테마 적용
### 기타
- react-quill -> react-quill-new 교체 (React 18+ findDOMNode 호환성)
- Write 페이지 제목 입력 UI 개선